### PR TITLE
Added https support and ability to specify additional parametes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,16 @@ from splunk_http_handler import SplunkHttpHandler
 import logging
 
 log = logging.getLogger('')
-log.addHandler(SplunkHttpHandler(host, port, token, host_name_override, source))
+log.addHandler(SplunkHttpHandler(host, token))
 log.setLevel('INFO')
 log.info("Testing")
 ```
 You should see the log message in your Splunk search.
+
+Additiona parameters can be passed to specify port, protocol, ssl verification, source, sourcetype, and hostname.
+
+for example:
+
+```
+log.addHandler(SplunkHttpHandler(host, token, port=8080, protocol='https', ssl_verify=True))
+```

--- a/splunk_http_handler/__init__.py
+++ b/splunk_http_handler/__init__.py
@@ -3,34 +3,49 @@ import logging
 import time
 import requests
 import ast
+from socket import gethostname
 
 class SplunkHttpHandler(logging.Handler):
-    URL_PATTERN = "http://{0}:{1}/services/collector"
+    URL_PATTERN = "{0}://{1}:{2}/services/collector"
 
-    def __init__(self, host, port, token, hostname='localhost', source='avadel_ims'):
+    def __init__(self, host, token, **kwargs):
         logging.Handler.__init__(self)
         self.host = host
-        self.port = port
         self.token = token
-        self.hostname = hostname
-        self.source = source
+        if kwargs is not None:
+            self.port = kwargs.pop('port') if 'port' in kwargs.keys() else 8080
+            self.proto = kwargs.pop('proto') if 'proto' in kwargs.keys() else 'https'
+            self.ssl_verify = kwargs.pop('ssl_verify') if 'ssl_verify' in kwargs.keys() else True
+            self.source = kwargs.pop('source') if 'source' in kwargs.keys() else None
+            self.sourcetype = kwargs.pop('sourcetype') if 'sourcetype' in kwargs.keys() else None
+            self.hostname = kwargs.pop('hostname') if 'hostname' in kwargs.keys() else gethostname()
+            # Remaining args
+            self.kwargs = kwargs.copy()
 
     def emit(self, record):
-        url = self.URL_PATTERN.format(self.host, self.port)
+        url = self.URL_PATTERN.format(self.proto, self.host, self.port)
 
         body = { 'log_level': record.levelname }
         try:
-            body.update(ast.literal_eval(record.msg))
+            # If record.msg is dict, leverage it as is
+            body.update(ast.literal_eval(str(record.msg)))
         except:
             body.update({ 'message': record.msg })
 
-        data = json.dumps({
-            'host': self.hostname, 'source': self.source, 'time': time.time(),
-            'event': body
-        })
+        event = dict({'host': self.hostname, 'source': self.source, 'sourcetype': self.sourcetype, 'event': body})
+        event.update(self.kwargs)
+
+        # Use timestamp from event if available
+        if body.has_key('time'):
+            event['time'] = body['time']
+        else:
+            event['time'] = time.time()
+
+        data = json.dumps(event, sort_keys=True)
 
         try:
-            r = requests.post(url, data=data, headers={ 'Authorization': "Splunk {}".format(self.token) }, verify=False)
+            r = requests.post(url, data=data, headers={ 'Authorization': "Splunk {}".format(self.token) },
+                              verify=self.ssl_verify)
             r.raise_for_status()
         except requests.exceptions.HTTPError as e:
             print e


### PR DESCRIPTION
- Added ability to specify protocol, sourcetype
- Hostname is set using socket.gethostname() call
- If 'time' is listed in event body, _time is set to it, otherwise current time is used
- If the event is of dict type, ast code now properly identifies it and preserves it